### PR TITLE
aosa.css: Use responsive page width on `body`

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -45,7 +45,7 @@ redirect_from:
     <img class="cover" src="../static/500l-cover.png" alt="500Lines Cover"/>
     <p><a href="buy.html#500L">Buy 500 Lines</a></p>
   </div>
-  <div class="col-8">
+  <div class="col-400px">
     <table>
       <tr>
         <td></td>
@@ -176,7 +176,7 @@ redirect_from:
     <img class="cover" id="posa-cover" src="../static/posa-cover.png" alt="POSA Cover"/>
     <p><a href="buy.html#posa">Buy POSA</a></p>
   </div>
-  <div class="col-8">
+  <div class="col-400px">
     <table>
       <tr>
         <td></td>
@@ -366,7 +366,7 @@ redirect_from:
     <img class="cover" src="../static/cover2.jpg" alt="Volume 2 cover"/>
     <p><a href="buy.html#vol2">Buy Volume II</a></p>
   </div>
-  <div class="col-8">
+  <div class="col-400px">
     <table>
       <tr>
         <td></td>
@@ -531,7 +531,7 @@ redirect_from:
     <img class="cover" src="../static/cover1.jpg" alt="Volume 1 cover"/> 
     <p><a href="buy.html#vol1">Buy Volume I</a></p>
   </div>
-  <div class="col-8">
+  <div class="col-400px">
     <table>
       <tr>
         <td align="right"></td>

--- a/static/aosa.css
+++ b/static/aosa.css
@@ -53,7 +53,7 @@ code, pre {
 }
 
 body {
-    width: 68rem;
+    max-width: 68rem;
     margin-left: 1rem;
 }
 

--- a/static/aosa.css
+++ b/static/aosa.css
@@ -28,6 +28,7 @@
 .col-10 { flex-basis: 83.33%; }
 .col-11 { flex-basis: 91.66%; }
 .col-12 { flex-basis: 100%; }
+.col-400px { flex-basis: 400px; }
 
 .left {
     text-align: left;


### PR DESCRIPTION
Forcing a a body width with `width: 68rem` breaks what would otherwise be a responsive page on mobile size viewports. 

Replacing `width` with `max-width` fixes this issue, and still prevents the page from growing too wide.